### PR TITLE
Adjustments for xcube-eopf

### DIFF
--- a/xarray_eopf/filter.py
+++ b/xarray_eopf/filter.py
@@ -16,7 +16,7 @@ def filter_dataset(
     if not variables:
         return dataset
     name_filter = NameFilter(includes=variables)
-    names = set(map(str, dataset.variables.keys()))
+    names = set(map(str, dataset.data_vars.keys()))
     # find all dataset variables including respective coordinates
     drop_names = names - set(name_filter.filter(names))
     if drop_names:


### PR DESCRIPTION
This change is needed for the Sentinel-3 implementation in xcube-eopf. 
It prevent that the 2d latitude and 2d longitude coordinate is not filtered out when filtering for variables. 