### PR TITLE
Fix package discovery in pyproject .toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,7 @@ version = {attr = "xarray_eopf.__version__"}
 readme = {file = "README.md", content-type = "text/markdown"}
 
 [tool.setuptools.packages.find]
-exclude = [
-  "tests",
-  "docs"
-]
+include = ["xarray_eopf*"]
 
 [tool.flake8]
 max-line-length = 88


### PR DESCRIPTION
The current content of the xarray-eopf wheel in PyPI is 

```
xarray_eopf-0.2.7-py3-none-any
├── integration
├── tests
├── xarray_eopf
└── xarray_eopf-0.2.7.dist-info
```

This path fixes the `setuptools` package discovery configuration to include only the `xarray-eopf` package and sub-packages.